### PR TITLE
Make sure service starts when VM restarted

### DIFF
--- a/modules/cavalcade/manifests/init.pp
+++ b/modules/cavalcade/manifests/init.pp
@@ -37,9 +37,17 @@ class cavalcade (
 	}
 
 	if versioncmp($::operatingsystemmajrelease, '15.04') >= 0 {
+		exec { 'systemctl enable cavalcade':
+			command     => '/bin/systemctl enable cavalcade',
+			refreshonly => true
+		}
 		file { '/lib/systemd/system/cavalcade.service':
 			ensure  => $file,
 			content => template('cavalcade/systemd.service.erb'),
+			notify  => [
+				Exec['systemctl-daemon-reload'],
+				Exec['systemctl enable cavalcade'],
+			],
 		}
 		File['/lib/systemd/system/cavalcade.service'] -> Service['cavalcade']
 	} else {

--- a/modules/cavalcade/templates/systemd.service.erb
+++ b/modules/cavalcade/templates/systemd.service.erb
@@ -11,4 +11,4 @@ User=www-data
 ExecStart=<%= @path %>/runner/bin/cavalcade
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=vagrant.mount


### PR DESCRIPTION
Because the service script is only available after the synced folders are mounted this changes the service's `WantedBy` value to `vagrant.mount` for `systemd`.

This in itself isn't enough as any changes to the service file require it to be re-enabled for the service to be properly symlinked.

There is still an outstanding issue whereby the service will fail to restart on a fresh provision because the service runner does not handle creating the cavalcade db tables.