### PR TITLE
Replace deprecated # comments with ;

### DIFF
--- a/modules/cavalcade/templates/cavalcade.ini.erb
+++ b/modules/cavalcade/templates/cavalcade.ini.erb
@@ -1,3 +1,3 @@
-# Override the disable_functions from our php.ini file in Chassis so we can use pcntl_signal
+; Override the disable_functions from our php.ini file in Chassis so we can use pcntl_signal
 
 disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,


### PR DESCRIPTION
These generate PHP deprecation notices in CLI and during provisioning